### PR TITLE
Fix typo

### DIFF
--- a/cfp.html
+++ b/cfp.html
@@ -28,6 +28,5 @@ navigation_weight: 7
 
 <h3>Submission Site</h3>
 <p>The submission site is <a href="https://cmt3.research.microsoft.com/AISTATS2021/">
-    https://cmt3.research.microsoft.com/AISTATS2020/</a></p>
+    https://cmt3.research.microsoft.com/AISTATS2021/</a></p>
 </p>
-


### PR DESCRIPTION
The year in the text of the CMT link is old. (the hyperlink is correct)